### PR TITLE
NOTICKET-Version-bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Genie Modular Game Engine",
     "license": "UNLICENSED",
     "private": true,


### PR DESCRIPTION
Bumps version so results screen and signals work can be pulled into the Genie starter pack.