### PR TITLE
Fix incorrect line numbers in stack traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,6 @@
             "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
             "dev": true
         },
-        "JSONStream": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-            "dev": true,
-            "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
-            }
-        },
         "abbrev": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -27,20 +17,31 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-            "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.17",
+                "mime-types": "2.1.18",
                 "negotiator": "0.6.1"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                }
             }
-        },
-        "acorn": {
-            "version": "4.0.13",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-            "dev": true
         },
         "acorn-dynamic-import": {
             "version": "3.0.0",
@@ -384,28 +385,10 @@
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
             "dev": true
         },
-        "array-filter": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-            "dev": true
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
             "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-            "dev": true
-        },
-        "array-map": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-            "dev": true
-        },
-        "array-reduce": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
             "dev": true
         },
         "array-slice": {
@@ -504,15 +487,6 @@
             "integrity": "sha512-UY7+9DPzlJ9VM8eY0b2TUZcZvF+1pO0hzMtAyjBYKhOmnvRlqYNYnWdtsMj0V16CGaMlpL0G1jnLbLo4AyotuQ==",
             "dev": true
         },
-        "astw": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-            "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
-            "dev": true,
-            "requires": {
-                "acorn": "4.0.13"
-            }
-        },
         "async": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -552,9 +526,9 @@
             "optional": true
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
             "dev": true,
             "optional": true
         },
@@ -566,6 +540,18 @@
             "optional": true,
             "requires": {
                 "follow-redirects": "1.0.0"
+            },
+            "dependencies": {
+                "follow-redirects": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
+                    "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.9"
+                    }
+                }
             }
         },
         "babel-code-frame": {
@@ -1650,15 +1636,7 @@
                 "on-finished": "2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.15"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                }
+                "type-is": "1.6.16"
             }
         },
         "boom": {
@@ -1668,7 +1646,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "brace-expansion": {
@@ -1716,97 +1694,11 @@
             "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
             "dev": true
         },
-        "browser-pack": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.3.tgz",
-            "integrity": "sha512-Jo+RYsn8X8OhyP9tMXXg0ueR2fW696HUu1Hf3/DeiwNean1oGiPtdgGRNuUHBpPHzBH3x4n1kzAlgOgHSIq88g==",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "combine-source-map": "0.8.0",
-                "defined": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3",
-                "umd": "3.0.1"
-            }
-        },
-        "browser-resolve": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-            "dev": true,
-            "requires": {
-                "resolve": "1.1.7"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-                    "dev": true
-                }
-            }
-        },
         "browser-stdout": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
-        },
-        "browserify": {
-            "version": "14.5.0",
-            "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
-            "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "assert": "1.4.1",
-                "browser-pack": "6.0.3",
-                "browser-resolve": "1.11.2",
-                "browserify-zlib": "0.2.0",
-                "buffer": "5.0.8",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "defined": "1.0.0",
-                "deps-sort": "2.0.0",
-                "domain-browser": "1.1.7",
-                "duplexer2": "0.1.4",
-                "events": "1.1.1",
-                "glob": "7.1.2",
-                "has": "1.0.1",
-                "htmlescape": "1.1.1",
-                "https-browserify": "1.0.0",
-                "inherits": "2.0.3",
-                "insert-module-globals": "7.0.1",
-                "labeled-stream-splicer": "2.0.0",
-                "module-deps": "4.1.1",
-                "os-browserify": "0.3.0",
-                "parents": "1.0.1",
-                "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "read-only-stream": "2.0.0",
-                "readable-stream": "2.3.3",
-                "resolve": "1.5.0",
-                "shasum": "1.0.2",
-                "shell-quote": "1.6.1",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.0",
-                "string_decoder": "1.0.3",
-                "subarg": "1.0.0",
-                "syntax-error": "1.3.0",
-                "through2": "2.0.3",
-                "timers-browserify": "1.4.2",
-                "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
-                "vm-browserify": "0.0.4",
-                "xtend": "4.0.1"
-            }
         },
         "browserify-aes": {
             "version": "1.1.1",
@@ -1886,16 +1778,6 @@
             "requires": {
                 "caniuse-lite": "1.0.30000792",
                 "electron-to-chromium": "1.3.31"
-            }
-        },
-        "buffer": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
-            "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
-            "dev": true,
-            "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.8"
             }
         },
         "buffer-more-ints": {
@@ -2016,12 +1898,6 @@
                     "dev": true
                 }
             }
-        },
-        "cached-path-relative": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-            "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
-            "dev": true
         },
         "caller-path": {
             "version": "0.1.0",
@@ -2190,9 +2066,9 @@
             }
         },
         "circular-json": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
-            "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.3.tgz",
+            "integrity": "sha512-YlxLOimeIoQGHnMe3kbf8qIV2Bj7uXLbljMPRguNT49GmSAzooNfS9EJ91rSJKbLBOOzM5agvtx0WyechZN/Hw==",
             "dev": true
         },
         "class-utils": {
@@ -2428,30 +2304,10 @@
                 "lodash": "4.17.4"
             }
         },
-        "combine-source-map": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
-            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-            "dev": true,
-            "requires": {
-                "convert-source-map": "1.1.3",
-                "inline-source-map": "0.6.2",
-                "lodash.memoize": "3.0.4",
-                "source-map": "0.5.7"
-            },
-            "dependencies": {
-                "convert-source-map": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-                    "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-                    "dev": true
-                }
-            }
-        },
         "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
                 "delayed-stream": "1.0.0"
@@ -2577,13 +2433,13 @@
             }
         },
         "connect": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
-            "integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+            "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "finalhandler": "1.0.6",
+                "finalhandler": "1.1.0",
                 "parseurl": "1.3.2",
                 "utils-merge": "1.0.1"
             }
@@ -2744,7 +2600,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -2952,7 +2808,7 @@
             "optional": true,
             "requires": {
                 "ast-types": "0.10.1",
-                "escodegen": "1.9.0",
+                "escodegen": "1.9.1",
                 "esprima": "3.1.3"
             }
         },
@@ -2982,18 +2838,6 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
-        },
-        "deps-sort": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
-            "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "shasum": "1.0.2",
-                "subarg": "1.0.0",
-                "through2": "2.0.3"
-            }
         },
         "des.js": {
             "version": "1.0.0",
@@ -3098,15 +2942,6 @@
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
-        "duplexer2": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.3"
-            }
-        },
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -3202,29 +3037,40 @@
             }
         },
         "engine.io": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.4.tgz",
-            "integrity": "sha1-PQIRtwpVLOhB/8fahiezAamkFi4=",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
+            "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
             "dev": true,
             "requires": {
-                "accepts": "1.3.3",
+                "accepts": "1.3.5",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "2.6.9",
+                "debug": "3.1.0",
                 "engine.io-parser": "2.1.2",
-                "uws": "0.14.5",
+                "uws": "9.14.0",
                 "ws": "3.3.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "engine.io-client": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.4.tgz",
-            "integrity": "sha1-T88TcLRxY70s6b4nM5ckMDUNTqE=",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+            "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "2.6.9",
+                "debug": "3.1.0",
                 "engine.io-parser": "2.1.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
@@ -3233,6 +3079,17 @@
                 "ws": "3.3.3",
                 "xmlhttprequest-ssl": "1.5.5",
                 "yeast": "0.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "engine.io-parser": {
@@ -3322,9 +3179,9 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-            "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+            "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -3332,7 +3189,16 @@
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "optionator": "0.8.2",
-                "source-map": "0.5.7"
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
             }
         },
         "eslint": {
@@ -3703,9 +3569,9 @@
             }
         },
         "eventemitter3": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+            "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
             "dev": true
         },
         "events": {
@@ -4114,9 +3980,9 @@
             }
         },
         "finalhandler": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-            "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+            "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
@@ -4202,13 +4068,23 @@
             }
         },
         "follow-redirects": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz",
-            "integrity": "sha1-jjQpjL0uF28lTv/sdaHHjMhJ/Tc=",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+            "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
             "dev": true,
-            "optional": true,
             "requires": {
-                "debug": "2.6.9"
+                "debug": "3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "for-in": {
@@ -4234,14 +4110,14 @@
             "optional": true
         },
         "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "optional": true,
             "requires": {
                 "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "mime-types": "2.1.17"
             }
         },
@@ -5870,7 +5746,7 @@
             "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
+                "hoek": "4.2.1",
                 "sntp": "2.1.0"
             }
         },
@@ -5888,7 +5764,7 @@
             "optional": true,
             "requires": {
                 "lodash": "4.17.4",
-                "request": "2.83.0"
+                "request": "2.85.0"
             }
         },
         "hmac-drbg": {
@@ -5903,9 +5779,9 @@
             }
         },
         "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
             "dev": true
         },
         "home-or-tmp": {
@@ -5931,12 +5807,6 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
             "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-            "dev": true
-        },
-        "htmlescape": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
             "dev": true
         },
         "http-auth": {
@@ -5984,12 +5854,13 @@
             "dev": true
         },
         "http-proxy": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-            "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
+                "eventemitter3": "3.0.1",
+                "follow-redirects": "1.4.1",
                 "requires-port": "1.0.0"
             }
         },
@@ -6013,7 +5884,7 @@
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "sshpk": "1.14.1"
             }
         },
         "httpntlm": {
@@ -6133,15 +6004,6 @@
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
         },
-        "inline-source-map": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
-            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-            "dev": true,
-            "requires": {
-                "source-map": "0.5.7"
-            }
-        },
         "inquirer": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -6213,42 +6075,6 @@
                     "requires": {
                         "has-flag": "3.0.0"
                     }
-                }
-            }
-        },
-        "insert-module-globals": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-            "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "combine-source-map": "0.7.2",
-                "concat-stream": "1.5.2",
-                "is-buffer": "1.1.6",
-                "lexical-scope": "1.2.0",
-                "process": "0.11.10",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
-            },
-            "dependencies": {
-                "combine-source-map": {
-                    "version": "0.7.2",
-                    "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
-                    "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
-                    "dev": true,
-                    "requires": {
-                        "convert-source-map": "1.1.3",
-                        "inline-source-map": "0.6.2",
-                        "lodash.memoize": "3.0.4",
-                        "source-map": "0.5.7"
-                    }
-                },
-                "convert-source-map": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-                    "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-                    "dev": true
                 }
             }
         },
@@ -6433,15 +6259,23 @@
                 "is-extglob": "1.0.0"
             }
         },
+        "is-my-ip-valid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "dev": true,
+            "optional": true
+        },
         "is-my-json-valid": {
-            "version": "2.17.1",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-            "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+            "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
             "dev": true,
             "optional": true,
             "requires": {
                 "generate-function": "2.0.0",
                 "generate-object-property": "1.2.0",
+                "is-my-ip-valid": "1.0.0",
                 "jsonpointer": "4.0.1",
                 "xtend": "4.0.1"
             }
@@ -7033,15 +6867,6 @@
             "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
             "dev": true
         },
-        "json-stable-stringify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-            "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-            "dev": true,
-            "requires": {
-                "jsonify": "0.0.0"
-            }
-        },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -7058,18 +6883,6 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
             "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
-        },
-        "jsonparse": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
             "dev": true
         },
         "jsonpointer": {
@@ -7135,32 +6948,31 @@
             "dev": true
         },
         "karma": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.0.tgz",
-            "integrity": "sha512-K9Kjp8CldLyL9ANSUctDyxC7zH3hpqXj/K09qVf06K3T/kXaHtFZ5tQciK7OzQu68FLvI89Na510kqQ2LCbpIw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.2.tgz",
+            "integrity": "sha1-TS25QChQpmVR+nhLAWT7CCTtjEs=",
             "dev": true,
             "requires": {
                 "bluebird": "3.5.1",
                 "body-parser": "1.18.2",
-                "browserify": "14.5.0",
                 "chokidar": "1.7.0",
                 "colors": "1.1.2",
                 "combine-lists": "1.0.1",
-                "connect": "3.6.5",
+                "connect": "3.6.6",
                 "core-js": "2.5.3",
                 "di": "0.0.1",
                 "dom-serialize": "2.2.1",
                 "expand-braces": "0.1.2",
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
-                "http-proxy": "1.16.2",
+                "http-proxy": "1.17.0",
                 "isbinaryfile": "3.0.2",
                 "lodash": "4.17.4",
-                "log4js": "2.5.2",
+                "log4js": "2.5.3",
                 "mime": "1.6.0",
                 "minimatch": "3.0.4",
                 "optimist": "0.6.1",
-                "qjobs": "1.1.5",
+                "qjobs": "1.2.0",
                 "range-parser": "1.2.0",
                 "rimraf": "2.6.2",
                 "safe-buffer": "5.1.1",
@@ -7356,25 +7168,6 @@
                 "graceful-fs": "4.1.11"
             }
         },
-        "labeled-stream-splicer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
-            "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
-            "dev": true,
-            "requires": {
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "stream-splicer": "2.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                }
-            }
-        },
         "lcid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -7392,15 +7185,6 @@
             "requires": {
                 "prelude-ls": "1.1.2",
                 "type-check": "0.3.2"
-            }
-        },
-        "lexical-scope": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-            "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
-            "dev": true,
-            "requires": {
-                "astw": "2.2.0"
             }
         },
         "libbase64": {
@@ -7715,12 +7499,6 @@
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
             "dev": true
         },
-        "lodash.memoize": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-            "dev": true
-        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -7805,14 +7583,14 @@
             }
         },
         "log4js": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.2.tgz",
-            "integrity": "sha512-MmZhzQCfCV5+nQgOqy34V9EV3k+Z/rPCdxyq+25EePKpwdUQxCb19BTmL5iX3iOCSAV/tWh7KVYqchwrx3+S2Q==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
+            "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
             "dev": true,
             "requires": {
                 "amqplib": "0.5.2",
                 "axios": "0.15.3",
-                "circular-json": "0.5.1",
+                "circular-json": "0.5.3",
                 "date-format": "1.2.0",
                 "debug": "3.1.0",
                 "hipchat-notifier": "1.1.0",
@@ -7896,7 +7674,7 @@
                     "optional": true,
                     "requires": {
                         "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
+                        "combined-stream": "1.0.6",
                         "mime-types": "2.1.17"
                     }
                 },
@@ -7909,7 +7687,7 @@
                     "requires": {
                         "chalk": "1.1.3",
                         "commander": "2.13.0",
-                        "is-my-json-valid": "2.17.1",
+                        "is-my-json-valid": "2.17.2",
                         "pinkie-promise": "2.0.1"
                     }
                 },
@@ -7941,7 +7719,7 @@
                     "requires": {
                         "assert-plus": "0.2.0",
                         "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
+                        "sshpk": "1.14.1"
                     }
                 },
                 "node-uuid": {
@@ -7966,10 +7744,10 @@
                     "optional": true,
                     "requires": {
                         "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
+                        "aws4": "1.7.0",
                         "bl": "1.1.2",
                         "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
+                        "combined-stream": "1.0.6",
                         "extend": "3.0.1",
                         "forever-agent": "0.6.1",
                         "form-data": "2.0.0",
@@ -7984,7 +7762,7 @@
                         "oauth-sign": "0.8.2",
                         "qs": "6.2.3",
                         "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
+                        "tough-cookie": "2.3.4",
                         "tunnel-agent": "0.4.3"
                     }
                 },
@@ -8114,7 +7892,7 @@
                     "optional": true,
                     "requires": {
                         "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
+                        "combined-stream": "1.0.6",
                         "mime-types": "2.1.17"
                     }
                 },
@@ -8580,29 +8358,6 @@
                         "has-flag": "2.0.0"
                     }
                 }
-            }
-        },
-        "module-deps": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
-            "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
-            "dev": true,
-            "requires": {
-                "JSONStream": "1.3.2",
-                "browser-resolve": "1.11.2",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
-                "defined": "1.0.0",
-                "detective": "4.7.1",
-                "duplexer2": "0.1.4",
-                "inherits": "2.0.3",
-                "parents": "1.0.1",
-                "readable-stream": "2.3.3",
-                "resolve": "1.5.0",
-                "stream-combiner2": "1.1.1",
-                "subarg": "1.0.0",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
             }
         },
         "morgan": {
@@ -13814,15 +13569,6 @@
                 "readable-stream": "2.3.3"
             }
         },
-        "parents": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-            "dev": true,
-            "requires": {
-                "path-platform": "0.11.15"
-            }
-        },
         "parse-asn1": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -13933,12 +13679,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-            "dev": true
-        },
-        "path-platform": {
-            "version": "0.11.15",
-            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
             "dev": true
         },
         "path-proxy": {
@@ -14265,9 +14005,15 @@
             "dev": true
         },
         "qjobs": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
-            "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+            "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
             "dev": true
         },
         "query-string": {
@@ -14385,15 +14131,6 @@
                 }
             }
         },
-        "read-only-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
-            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.3"
-            }
-        },
         "read-pkg": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -14501,14 +14238,14 @@
             "optional": true,
             "requires": {
                 "double-ended-queue": "2.1.0-0",
-                "redis-commands": "1.3.1",
+                "redis-commands": "1.3.5",
                 "redis-parser": "2.6.0"
             }
         },
         "redis-commands": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-            "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs=",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
+            "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA==",
             "dev": true,
             "optional": true
         },
@@ -14680,19 +14417,19 @@
             "dev": true
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "dev": true,
             "optional": true,
             "requires": {
                 "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
+                "aws4": "1.7.0",
                 "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
+                "form-data": "2.3.2",
                 "har-validator": "5.0.3",
                 "hawk": "6.0.2",
                 "http-signature": "1.2.0",
@@ -14705,18 +14442,9 @@
                 "qs": "6.5.1",
                 "safe-buffer": "5.1.1",
                 "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
+                "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
                 "uuid": "3.2.1"
-            },
-            "dependencies": {
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "requestretry": {
@@ -14728,7 +14456,7 @@
             "requires": {
                 "extend": "3.0.1",
                 "lodash": "4.17.4",
-                "request": "2.83.0",
+                "request": "2.85.0",
                 "when": "3.7.8"
             }
         },
@@ -15105,16 +14833,6 @@
                 "safe-buffer": "5.1.1"
             }
         },
-        "shasum": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-            "dev": true,
-            "requires": {
-                "json-stable-stringify": "0.0.1",
-                "sha.js": "2.4.10"
-            }
-        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15129,18 +14847,6 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
             "dev": true
-        },
-        "shell-quote": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-            "dev": true,
-            "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
-            }
         },
         "shelljs": {
             "version": "0.8.1",
@@ -15354,7 +15060,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "socket.io": {
@@ -15364,10 +15070,10 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "engine.io": "3.1.4",
+                "engine.io": "3.1.5",
                 "socket.io-adapter": "1.1.1",
                 "socket.io-client": "2.0.4",
-                "socket.io-parser": "3.1.2"
+                "socket.io-parser": "3.1.3"
             }
         },
         "socket.io-adapter": {
@@ -15387,28 +15093,37 @@
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
                 "debug": "2.6.9",
-                "engine.io-client": "3.1.4",
+                "engine.io-client": "3.1.6",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "3.1.2",
+                "socket.io-parser": "3.1.3",
                 "to-array": "0.1.4"
             }
         },
         "socket.io-parser": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.2.tgz",
-            "integrity": "sha1-28IoIVH8T6675Aru3Ady66YZ9/I=",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
+            "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "2.6.9",
+                "debug": "3.1.0",
                 "has-binary2": "1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
                 "isarray": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -15541,9 +15256,9 @@
             "dev": true
         },
         "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
             "optional": true,
             "requires": {
@@ -15612,16 +15327,6 @@
                 "duplexer": "0.1.1"
             }
         },
-        "stream-combiner2": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.3.3"
-            }
-        },
         "stream-each": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -15650,16 +15355,6 @@
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
             "dev": true
-        },
-        "stream-splicer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-            "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
-            "dev": true,
-            "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
-            }
         },
         "stream-to-observable": {
             "version": "0.2.0",
@@ -15811,23 +15506,6 @@
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
-        "subarg": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-            "dev": true,
-            "requires": {
-                "minimist": "1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
-            }
-        },
         "supports-color": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -15839,15 +15517,6 @@
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
             "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
             "dev": true
-        },
-        "syntax-error": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
-            "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
-            "dev": true,
-            "requires": {
-                "acorn": "4.0.13"
-            }
         },
         "table": {
             "version": "4.0.2",
@@ -15983,15 +15652,6 @@
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
             "dev": true
         },
-        "timers-browserify": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-            "dev": true,
-            "requires": {
-                "process": "0.11.10"
-            }
-        },
         "timespan": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/timespan/-/timespan-2.3.0.tgz",
@@ -16069,9 +15729,9 @@
             }
         },
         "tough-cookie": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -16136,13 +15796,30 @@
             "dev": true
         },
         "type-is": {
-            "version": "1.6.15",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "version": "1.6.16",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.17"
+                "mime-types": "2.1.18"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.33.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+                    "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.18",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+                    "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.33.0"
+                    }
+                }
             }
         },
         "typedarray": {
@@ -16236,12 +15913,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
             "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-            "dev": true
-        },
-        "umd": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
-            "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
             "dev": true
         },
         "underscore": {
@@ -16509,9 +16180,9 @@
             "dev": true
         },
         "uws": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/uws/-/uws-0.14.5.tgz",
-            "integrity": "sha1-Z6rzPEaypYel9mZtAPdpEyjxSdw=",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
+            "integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
             "dev": true,
             "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "hard-source-webpack-plugin": "^0.6.4",
         "istanbul-instrumenter-loader": "^3.0.0",
         "jsdoc": "^3.5.5",
-        "karma": "^2.0.0",
+        "karma": "^2.0.2",
         "karma-chrome-launcher": "^2.2.0",
         "karma-coverage": "^1.1.1",
         "karma-mocha": "^1.3.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
         frameworks: ["mocha"],
         files: ["node_modules/phaser-ce/build/phaser.min.js", "test/test-context.js"],
         preprocessors: {
-            "test/test-context.js": ["webpack"],
+            "test/test-context.js": ["webpack", "sourcemap"],
         },
         client: {
             mocha: {


### PR DESCRIPTION
Currently on master when a test fails or throws an exception we get a stack trace similar to the following:
```
FAILED TESTS:
  Pause Overlay
    assets
      ✖ restores disabled buttons on destroy
        HeadlessChrome 0.0.0 (Mac OS X 10.12.6)
      AssertionError: expected true to be false
          at Context.it (base/test/test-context.js?a24f68806f9cfb1eceb76d737805b13223fdaa11:113825:57)
```
This PR updates karma and adds the `sourcemap` preprocessor which makes the stack traces look like this:
```
FAILED TESTS:
  Pause Overlay
    assets
      ✖ restores disabled buttons on destroy
        HeadlessChrome 0.0.0 (Mac OS X 10.12.6)
      AssertionError: expected true to be false
          at Context.it (webpack:///test/components/pause.spec.js:129:0 <- test/test-context.js:113825:57)
```

Ideally we'd just get something like `test/components/pause.spec.js:129:0` which would make it a followable link in vscode but this is the closest I could get. I guess it's a trade off for bundling the tests.

*EDIT: Not only are the tests much slower when they're all in their own bundles but the stack traces are no more helpful.*