### PR TITLE
Update for Version 0.6 : Final Fantasy VII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| UNRELEASED | |
+| 0.6.0 | |
 | | Fixes an issue on iPhone X where voice-over tabbing would begin at the end of the how-to-play and select screens |
 | | Adds mandatory stats using the GMI. |
 | | Enable audio toggle button |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Genie Modular Game Engine",
     "license": "UNLICENSED",
     "private": true,


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/961406/43523660-033d060e-9595-11e8-918e-55a4a65305f6.gif" width="648"  />

# Genie 0.6: Final Fantasy VII
* Fixes an issue on iPhone X where voice-over tabbing would begin at the end of the how-to-play and select screens
* Adds mandatory stats using the GMI.
* Enable audio toggle button
* Adds an `accessibility-layer` that manages accessible DOM elements from screen-to-screen
* Fix default actions not applying to overlay buttons.
* Fixes regression bug where the settings icons were not updating correctly.
* Fix prev/next buttons appearing under character sprite on select screen.
* Prevent iOS voiceover from jumping the screen up and down.
* Fixes incorrect stats label.
* Ensures audio and motion icons appear in the correct order.
* Stops screenreader on book from reading out the hidden carousel arrows at either end on How To Play.