### PR TITLE
Update unit test button priorities to match

### DIFF
--- a/src/components/overlays/overlay-layout.js
+++ b/src/components/overlays/overlay-layout.js
@@ -10,10 +10,8 @@ import fp from "../../../lib/lodash/fp/fp.js";
  * - Adding a background
  * - Moving GEL buttons to the top
  */
-
 export function create(screen) {
-    const backgroundPriorityID = 999;
-    const priorityID = backgroundPriorityID + screen.context.popupScreens.length;
+    const priorityID = 999 + 2 * screen.context.popupScreens.length; //* 2 to provide space between layers for background
     return {
         addBackground,
         moveGelButtonsToTop,

--- a/test/components/overlays/overlay-layout.spec.js
+++ b/test/components/overlays/overlay-layout.spec.js
@@ -45,7 +45,7 @@ describe("Overlay Layout", () => {
             overlayLayout.addBackground(mockBackgroundImage);
 
             assert.isTrue(mockBackgroundImage.inputEnabled);
-            assert.equal(mockBackgroundImage.input.priorityID, 1000);
+            assert.equal(mockBackgroundImage.input.priorityID, 1002);
             assert.deepEqual(mockScreen.scene.addToBackground.getCall(0).args[0], mockBackgroundImage);
         });
     });
@@ -66,7 +66,7 @@ describe("Overlay Layout", () => {
                 },
             };
             overlayLayout.moveGelButtonsToTop(mockGelLayout);
-            assert.equal(mockGelLayout.buttons.audio.input.priorityID, 1001);
+            assert.equal(mockGelLayout.buttons.audio.input.priorityID, 1003);
             assert.equal(mockGelLayout.buttons.audio.parent.updateTransform.calledOnce, true);
             assert.equal(mockGelLayout.buttons.audio.parent.parent.updateTransform.calledOnce, true);
             assert.equal(mockGelLayout.buttons.audio.update.calledOnce, true);
@@ -82,7 +82,7 @@ describe("Overlay Layout", () => {
             };
             overlayLayout.moveToTop(mockItem);
             assert.isTrue(mockItem.inputEnabled);
-            assert.equal(mockItem.input.priorityID, 1001);
+            assert.equal(mockItem.input.priorityID, 1003);
         });
     });
 });


### PR DESCRIPTION
![Hooper](https://user-images.githubusercontent.com/961406/44262443-fe0a5080-a212-11e8-8a72-0451f5bf17f9.gif)



Adds some separation between butotn priority "layers" so that they don't overlap when multiple overlays are used.