### PR TITLE
Add async flag to script loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 | Version | Description |
 |---------|-------------|
-| UNRELEASED | |
+| 1.0.3 | |
+| | Load global scripts synchronously in dev build |
 | | Fix ios voiceover reading out zombie element . |
 | | Prevent double tap zoom in developer pages. |
 | 1.0.2 | |

--- a/dev/scripts/dynamicScripts.js
+++ b/dev/scripts/dynamicScripts.js
@@ -9,6 +9,7 @@
 function dynamicallyLoadScript(url) {
     var script = document.createElement("script");
     script.src = url;
+    script.async = false;
     document.head.appendChild(script);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,


### PR DESCRIPTION

![insta](https://user-images.githubusercontent.com/961406/48189591-77a86b00-e338-11e8-88c8-73d67ae2df78.gif)


Bump version to 1.03

Add async flag to scripts so that dev global scripts are loaded in the correct order.

ref: https://www.html5rocks.com/en/tutorials/speed/script-loading/