### PR TITLE
Config webpack to create output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Configure webpack-dev-server to store server output on disk. |
 | | Changes fullscreen target for Phaser to ensure the settings screen and Brim appear above the fullscreen game, adds mock GMI for local testing. |
 | 1.0.7 | |
 | | Add lib folder to babel load in webpack config. |

--- a/build-scripts/webpack.config.js
+++ b/build-scripts/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = env => {
             ],
         },
         devServer: {
+            writeToDisk: true,
             useLocalIp: true,
             host: "0.0.0.0",
             historyApiFallback: {


### PR DESCRIPTION
Change webpack-dev-server to write output to disk rather than storing entirely in memory.