### PR TITLE
Report settings closed from callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Set statsScreen to settings when closed, to report correct previous page. |
 | 1.0.10 | |
 | | Upgrade to Babel 7. |
 | | Updates stats calls for ATI. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "1.0.8",
+    "version": "1.0.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -4477,7 +4477,7 @@
         },
         "event-stream": {
             "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
@@ -5493,7 +5493,6 @@
                     "version": "2.3.5",
                     "resolved": false,
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5512,7 +5511,6 @@
                     "version": "0.5.1",
                     "resolved": false,
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5692,8 +5690,7 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": false,
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "optional": true
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5799,8 +5796,7 @@
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": false,
-                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "optional": true
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
                 }
             }
         },

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -97,7 +97,6 @@ export const config = {
         channel: buttonsChannel,
         action: ({ game }) => {
             settings.show(game);
-            gmi.sendStatsEvent("settings", "open");
         },
     },
     pause: {

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -15,6 +15,7 @@ export const create = () => {
         name: "settings-closed",
         callback: () => {
             setAccessibleLayer(true);
+            gmi.sendStatsEvent("settings", "close", {});
         },
     });
 

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -10,12 +10,14 @@ import { gmi } from "./gmi/gmi.js";
 export const settingsChannel = "genie-settings";
 
 export const create = () => {
+    let screenToReturnTo;
+
     signal.bus.subscribe({
         channel: settingsChannel,
         name: "settings-closed",
         callback: () => {
             setAccessibleLayer(true);
-            gmi.setStatsScreen("settings");
+            gmi.setStatsScreen(screenToReturnTo);
         },
     });
 
@@ -35,10 +37,12 @@ export const create = () => {
     };
 
     return {
-        show: () => {
+        show: game => {
             // get current buttons
+            screenToReturnTo = game.state.current;
             setAccessibleLayer(false);
 
+            gmi.setStatsScreen("settings");
             return gmi.showSettings(onSettingChanged, onSettingsClosed);
         },
         getAllSettings: () => gmi.getAllSettings(),

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -15,7 +15,7 @@ export const create = () => {
         name: "settings-closed",
         callback: () => {
             setAccessibleLayer(true);
-            gmi.sendStatsEvent("settings", "close", {});
+            gmi.setStatsScreen("settings");
         },
     });
 

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -41,8 +41,6 @@ export const create = () => {
             // get current buttons
             screenToReturnTo = game.state.current;
             setAccessibleLayer(false);
-
-            gmi.setStatsScreen("settings");
             return gmi.showSettings(onSettingChanged, onSettingsClosed);
         },
         getAllSettings: () => gmi.getAllSettings(),

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -112,10 +112,6 @@ describe("Layout - Gel Defaults", () => {
         test("shows the settings", () => {
             expect(settings.show).toHaveBeenCalled();
         });
-
-        test("sends a stat to the GMI", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("settings", "open");
-        });
     });
 
     describe("Pause Button Callback", () => {

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -17,7 +17,11 @@ describe("Settings", () => {
     let settings;
 
     const createGmi = () => {
-        mockGmi = { showSettings: jest.fn(() => "show settings"), getAllSettings: jest.fn() };
+        mockGmi = {
+            showSettings: jest.fn(() => "show settings"),
+            getAllSettings: jest.fn(),
+            sendStatsEvent: jest.fn(),
+        };
         createMockGmi(mockGmi);
     };
 

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -105,6 +105,16 @@ describe("Settings", () => {
             expect(publishConfig.channel).toBe(expectedSignal.channel);
             expect(publishConfig.name).toBe(expectedSignal.name);
         });
+
+        test("sets the stats screen when settings is closed", () => {
+            settings.show(mockGame);
+            const onSettingsClosedCallback = mockGmi.showSettings.mock.calls[0][1];
+            onSettingsClosedCallback();
+            const subscribeCallback = signal.bus.subscribe.mock.calls[0][0].callback;
+            subscribeCallback();
+
+            expect(mockGmi.setStatsScreen).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("getAllSettings method", () => {

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -106,14 +106,19 @@ describe("Settings", () => {
             expect(publishConfig.name).toBe(expectedSignal.name);
         });
 
-        test("sets the stats screen when settings is closed", () => {
+        test("sets the stats screen to settings when settings is opened", () => {
+            settings.show(mockGame);
+            expect(mockGmi.setStatsScreen).toHaveBeenCalledWith("settings");
+        });
+
+        test("sets the stats screen back when settings is closed", () => {
             settings.show(mockGame);
             const onSettingsClosedCallback = mockGmi.showSettings.mock.calls[0][1];
             onSettingsClosedCallback();
             const subscribeCallback = signal.bus.subscribe.mock.calls[0][0].callback;
             subscribeCallback();
 
-            expect(mockGmi.setStatsScreen).toHaveBeenCalledTimes(1);
+            expect(mockGmi.setStatsScreen).toHaveBeenCalledWith("current-screen");
         });
     });
 

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -20,7 +20,7 @@ describe("Settings", () => {
         mockGmi = {
             showSettings: jest.fn(() => "show settings"),
             getAllSettings: jest.fn(),
-            sendStatsEvent: jest.fn(),
+            setStatsScreen: jest.fn(),
         };
         createMockGmi(mockGmi);
     };

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -106,11 +106,6 @@ describe("Settings", () => {
             expect(publishConfig.name).toBe(expectedSignal.name);
         });
 
-        test("sets the stats screen to settings when settings is opened", () => {
-            settings.show(mockGame);
-            expect(mockGmi.setStatsScreen).toHaveBeenCalledWith("settings");
-        });
-
         test("sets the stats screen back when settings is closed", () => {
             settings.show(mockGame);
             const onSettingsClosedCallback = mockGmi.showSettings.mock.calls[0][1];


### PR DESCRIPTION
Send a stats event with settings~closed when the settings screen is closed

sendStatsEvent in Genie appears to report the current screen itself, so shouldn't need any extra calls beforehand?