### PR TITLE
CGPROD-1404-Stats-Bugs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 | Version | Description |
 |---------|-------------|
 | UNRELEASED | |
+| | Fixes some stats bugs. |
 | | Adds pause click stat. |
 | | Ensures click and page stats are firing in the correct order. |
 | | Improves stats logging for results/score screen. |

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,10 +8,10 @@ module.exports = {
     collectCoverageFrom: ["src/**/*.js", "!src/components/test-harness/**/*.js", "!src/output/**/*.js"],
     coverageThreshold: {
         global: {
-            statements: 90.0,
-            branches: 83.33,
-            functions: 86.1,
-            lines: 91.0,
+            statements: 90.86,
+            branches: 84.09,
+            functions: 86.26,
+            lines: 91.99,
         },
     },
     testEnvironment: "jsdom",

--- a/src/components/overlays/how-to-play.js
+++ b/src/components/overlays/how-to-play.js
@@ -95,7 +95,7 @@ export function create({ game }) {
         destroyPips();
         title.destroy();
         background.destroy();
-        screen.overlayClosed.dispatch();
+        signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: true } });
         screen.scene.removeLast();
     }
 }

--- a/src/components/overlays/pause.js
+++ b/src/components/overlays/pause.js
@@ -71,7 +71,7 @@ export const create = fp.curry((hideReplayButton, { game }) => {
 
             GameSound.Assets.backgroundMusic.resume();
         }
-        screen.overlayClosed.dispatch();
+        signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
         screen.scene.removeLast();
     }
 

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -54,6 +54,9 @@ export const config = {
         order: 2,
         id: "__back",
         channel: buttonsChannel,
+        action: () => {
+            gmi.sendStatsEvent("home", "click");
+        },
     },
     howToPlayBack: {
         group: "topLeft",
@@ -63,6 +66,9 @@ export const config = {
         order: 2,
         id: "__back",
         channel: "how-to-play-gel-buttons",
+        action: () => {
+            gmi.sendStatsEvent("home", "click");
+        },
     },
     audio: {
         group: "topRight",

--- a/test/components/overlays/how-to-play.test.js
+++ b/test/components/overlays/how-to-play.test.js
@@ -30,6 +30,7 @@ describe("How To Play Overlay", () => {
         };
 
         jest.spyOn(signal.bus, "subscribe");
+        jest.spyOn(signal.bus, "publish");
         jest.spyOn(Book, "Start").mockImplementation(() => mockBook);
         jest.spyOn(Book, "PreviousPage").mockImplementation(() => mockBook);
         jest.spyOn(Book, "NextPage").mockImplementation(() => mockBook);
@@ -60,9 +61,6 @@ describe("How To Play Overlay", () => {
                         },
                     },
                 },
-            },
-            overlayClosed: {
-                dispatch: jest.fn(),
             },
         };
 
@@ -217,8 +215,12 @@ describe("How To Play Overlay", () => {
                 expect(mockTitle.destroy).toHaveBeenCalledTimes(1);
             });
 
-            test("dispatches overlayClosed signal on screen", () => {
-                expect(mockScreen.overlayClosed.dispatch).toHaveBeenCalled();
+            test("dispatches a signal to close the overlay and fire a page stat", () => {
+                expect(signal.bus.publish).toHaveBeenCalledWith({
+                    channel: "overlays",
+                    name: "overlay-closed",
+                    data: { firePageStat: true },
+                });
             });
 
             test("removes the scene", () => {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -64,6 +64,26 @@ describe("Layout - Gel Defaults", () => {
         });
     });
 
+    describe("Back Button Callback", () => {
+        beforeEach(() => {
+            gel.config.back.action();
+        });
+
+        test("fires a click stat", () => {
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("home", "click");
+        });
+    });
+
+    describe("How To Play Back Button Callback", () => {
+        beforeEach(() => {
+            gel.config.howToPlayBack.action();
+        });
+
+        test("fires a click stat", () => {
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("home", "click");
+        });
+    });
+
     describe("Audio Callback", () => {
         beforeEach(() => {
             jest.spyOn(signal.bus, "publish");

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -10,18 +10,17 @@ import { createMockGame } from "../mock/phaser-game.js";
 import * as GameSound from "../../src/core/game-sound";
 import * as VisibleLayer from "../../src/core/visible-layer.js";
 import * as a11y from "../../src/core/accessibility/accessibility-layer.js";
+import * as signal from "../../src/core/signal-bus.js";
 
 describe("Screen", () => {
     let screen;
     let mockGmi;
     let mockScene;
     let mockContext;
-    let signalInstance;
     let mockTransientData;
 
     const createScreen = () => {
         screen = new Screen();
-        jest.spyOn(screen, "onOverlayClosed");
         mockTransientData = { transient: "data" };
         screen.game = createMockGame();
         screen.game.state.current = "loadscreen";
@@ -40,31 +39,28 @@ describe("Screen", () => {
         initScreen();
     };
 
+    beforeEach(() => {
+        jest.spyOn(signal.bus, "subscribe");
+        jest.spyOn(GameSound, "setupScreenMusic").mockImplementation(() => {});
+        jest.spyOn(VisibleLayer, "get").mockImplementation(() => "current-layer");
+        jest.spyOn(a11y, "clearElementsFromDom").mockImplementation(() => {});
+        jest.spyOn(a11y, "clearAccessibleButtons").mockImplementation(() => {});
+        jest.spyOn(a11y, "appendElementsToDom").mockImplementation(() => {});
+
+        mockScene = { addToBackground: jest.fn() };
+        mockGmi = { setStatsScreen: jest.fn() };
+        createMockGmi(mockGmi);
+
+        mockContext = {
+            popupScreens: ["pause"],
+            config: { theme: { loadscreen: { music: "test/music" } } },
+        };
+        delete window.__qaMode;
+    });
+
     afterEach(() => jest.clearAllMocks());
 
-    describe("with context", () => {
-        beforeEach(() => {
-            mockScene = { addToBackground: jest.fn() };
-            jest.spyOn(GameSound, "setupScreenMusic").mockImplementation(() => {});
-            jest.spyOn(VisibleLayer, "get").mockImplementation(() => "current-layer");
-            jest.spyOn(a11y, "clearElementsFromDom").mockImplementation(() => {});
-            jest.spyOn(a11y, "clearAccessibleButtons").mockImplementation(() => {});
-            jest.spyOn(a11y, "appendElementsToDom").mockImplementation(() => {});
-            signalInstance = { add: jest.fn() };
-            jest.spyOn(Phaser, "Signal").mockImplementation(() => signalInstance);
-            mockGmi = { setStatsScreen: jest.fn() };
-            createMockGmi(mockGmi);
-            mockContext = {
-                popupScreens: ["pause"],
-                config: {
-                    theme: {
-                        loadscreen: { music: "test/music" },
-                    },
-                },
-            };
-            delete window.__qaMode;
-        });
-
+    describe("Initialisation", () => {
         test("sets the scene", () => {
             createAndInitScreen();
             expect(screen.scene).toEqual(mockScene);
@@ -117,13 +113,11 @@ describe("Screen", () => {
 
         test("creates the overlay closed signal", () => {
             createAndInitScreen();
-            expect(screen.overlayClosed).toEqual(signalInstance);
-        });
-
-        test("adds a listener to overlayClosed signal", () => {
-            createAndInitScreen();
-            expect(signalInstance.add).toHaveBeenCalledTimes(1);
-            expect(signalInstance.add).toHaveBeenCalledWith(screen.onOverlayClosed, screen);
+            expect(signal.bus.subscribe).toHaveBeenCalledWith({
+                channel: "overlays",
+                name: "overlay-closed",
+                callback: expect.any(Function),
+            });
         });
     });
 
@@ -136,9 +130,13 @@ describe("Screen", () => {
         test("sets context by merging new value with current value", () => {
             const expectedContext = {
                 popupScreens: ["pause"],
-                config: { theme: { loadscreen: { music: "test/music" } } },
+                config: {
+                    theme: { loadscreen: { music: "test/music" }, pause: { data: "some-data" } },
+                },
             };
             createAndInitScreen();
+            screen.context = { config: { theme: { pause: { data: "some-data" } } } };
+
             expect(screen.context).toEqual(expectedContext);
         });
     });
@@ -160,34 +158,42 @@ describe("Screen", () => {
         });
     });
 
-    describe("when overlayClosed signal is triggered", () => {
+    describe("When overlay-closed signal is fired", () => {
         beforeEach(() => {
-            screen = new Screen();
-            screen.game = createMockGame();
-            screen.context = { popupScreens: ["how-to-play"] };
-            screen.onOverlayClosed();
+            mockContext.popupScreens = ["how-to-play"];
+            createAndInitScreen();
         });
 
         test("clears accessible elements from DOM", () => {
-            expect(a11y.clearElementsFromDom).toHaveBeenCalledTimes(1);
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
+            expect(a11y.clearElementsFromDom).toHaveBeenCalledTimes(2);
         });
 
         test("clears accessible buttons object", () => {
-            expect(a11y.clearAccessibleButtons).toHaveBeenCalledTimes(1);
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
+            expect(a11y.clearAccessibleButtons).toHaveBeenCalledTimes(2);
             expect(a11y.clearAccessibleButtons).toHaveBeenCalledWith(screen);
         });
 
         test("removes latest popup screen from popupScreens array", () => {
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
             expect(screen.context.popupScreens).toEqual([]);
         });
 
         test("appends accessible elements to DOM", () => {
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
             expect(a11y.appendElementsToDom).toHaveBeenCalledTimes(1);
             expect(a11y.appendElementsToDom).toHaveBeenCalledWith(screen);
         });
 
-        test("sets the stats screen to the current screen", () => {
+        test("fires a page stat with the current screen when firePageStat is true", () => {
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: true } });
             expect(mockGmi.setStatsScreen).toHaveBeenCalledWith(screen.game.state.current);
+        });
+
+        test("does not fire a page stat when firePageStat is false", () => {
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
+            expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
         });
     });
 });

--- a/test/core/screen.test.js
+++ b/test/core/screen.test.js
@@ -41,6 +41,7 @@ describe("Screen", () => {
 
     beforeEach(() => {
         jest.spyOn(signal.bus, "subscribe");
+        jest.spyOn(signal.bus, "removeChannel");
         jest.spyOn(GameSound, "setupScreenMusic").mockImplementation(() => {});
         jest.spyOn(VisibleLayer, "get").mockImplementation(() => "current-layer");
         jest.spyOn(a11y, "clearElementsFromDom").mockImplementation(() => {});
@@ -194,6 +195,11 @@ describe("Screen", () => {
         test("does not fire a page stat when firePageStat is false", () => {
             signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
             expect(mockGmi.setStatsScreen).not.toHaveBeenCalled();
+        });
+
+        test("removes the overlays channel", () => {
+            signal.bus.publish({ channel: "overlays", name: "overlay-closed", data: { firePageStat: false } });
+            expect(signal.bus.removeChannel).toHaveBeenCalledTimes(1);
         });
     });
 });


### PR DESCRIPTION
- Ensures click is fired when clicking the "home" button.
- Ensures page stat does not fire twice when navigating results => pause => replay
- Fixes subtle bug where new "overlays" channel was created multiple times.

![](https://media.giphy.com/media/oFLtB1ltV6u08/giphy.gif)