### PR TITLE
configPath Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Embedvars configPath is now just the path, not path + filename |
 | 1.0.12 | |
 | | Prune scripts list |
 | | Update webpack config so we can provide sourcemaps when needed |

--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -201,7 +201,7 @@ function configureGmi(gameDir, themesDir) {
     var embedVars = {
         statsCounterName: "testCounterName",
         statsAppName: "TestAppName",
-        configPath: themesDir + theme + "/config.json",
+        configPath: themesDir + theme + "/",
     };
 
     window.getGMI = function(options) {

--- a/src/core/startup.js
+++ b/src/core/startup.js
@@ -90,8 +90,7 @@ class Startup extends Phaser.State {
         this.game.load.baseURL = gmi.gameDir;
 
         // All asset paths are relative to the location of the config.json:
-        const theme = gmi.embedVars.configPath;
-        this.game.load.path = theme.split(/([^/]+$)/, 2)[0]; //config dir
+        this.game.load.path = gmi.embedVars.configPath; //config dir
         this.game.load.json(CONFIG_KEY, "config.json");
 
         signal.bus.subscribe({


### PR DESCRIPTION

![fractalus](https://user-images.githubusercontent.com/961406/59802302-a5975a00-92e0-11e9-8301-451391c196f3.gif)



* Use configPath directly rather than stripping file from path then adding it back on again.

It is actually safe to change the embed vars for older Genie games because all they did was strip the filename off only to add it back again.

*e.g.*
```Javascript
"themes/frog/config.json".split(/([^/]+$)/, 2)[0]
_>>> "themes/frog/"_
"themes/frog/".split(/([^/]+$)/, 2)[0]
_>>> "themes/frog/"_
```
gives same results.

The gmi templates for achievements need these to be correct however.