### PR TITLE
Report "back" rather than "home" on back button click

### DIFF
--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -67,7 +67,7 @@ export const config = {
         id: "__back",
         channel: "how-to-play-gel-buttons",
         action: () => {
-            gmi.sendStatsEvent("home", "click");
+            gmi.sendStatsEvent("back", "click");
         },
     },
     audio: {

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -55,7 +55,7 @@ export const config = {
         id: "__back",
         channel: buttonsChannel,
         action: () => {
-            gmi.sendStatsEvent("home", "click");
+            gmi.sendStatsEvent("back", "click");
         },
     },
     howToPlayBack: {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -80,7 +80,7 @@ describe("Layout - Gel Defaults", () => {
         });
 
         test("fires a click stat", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("home", "click");
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("back", "click");
         });
     });
 

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -70,7 +70,7 @@ describe("Layout - Gel Defaults", () => {
         });
 
         test("fires a click stat", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("home", "click");
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("back", "click");
         });
     });
 


### PR DESCRIPTION
Should report an ati back\~click rather than home\~click when you click back.