### PR TITLE
Replace broken references to 'this'

### DIFF
--- a/dev/scripts/gmi.js
+++ b/dev/scripts/gmi.js
@@ -139,7 +139,7 @@ var GMI = function(options, embedVars, gameDir) {
     GMI.prototype.showSettings = function(onSettingsChanged, onSettingsClosed) {
         var settingsDiv = document.getElementsByClassName("settings");
         if (!(settingsDiv && settingsDiv[0])) {
-            this.sendStatsEvent("settings", "open", {});
+            GMI.prototype.sendStatsEvent("settings", "open", {});
             var settings = document.createElement('div');
             settings.className = "settings"
             settings.innerHTML += "The settings screen will appear here when the game is hosted on the BBC servers <br />";
@@ -209,13 +209,13 @@ var GMI = function(options, embedVars, gameDir) {
             Object.assign(stored, update);
             console.log("UPDATE LOCAL DATA: ", stored, " -- TO: ", update);
         }
-        this.setGameData("achievements", globalSettings.achievements);
+        GMI.prototype.setGameData("achievements", globalSettings.achievements);
     };
 
     GMI.prototype.achievements.show = function() {
         var achievementsDiv = document.getElementsByClassName("achievements");
         if (!(achievementsDiv && achievementsDiv[0])) {
-            this.sendStatsEvent("achievements", "open", {});
+            GMI.prototype.sendStatsEvent("achievements", "open", {});
             var achievementsDiv = document.createElement('div');
             achievementsDiv.className = "achievements"
             achievementsDiv.innerHTML += "The achievements screen will appear here when the game is hosted on the BBC servers <br />";


### PR DESCRIPTION
Turns out `this` doesn't work quite the way I thought it did, it's causing the page to break when anything attempts to use `GMI.achievements.show`.

Reverting references to `this` back to `GMI.prototype` fixes this issue