### PR TITLE
CGPROD-1790 Fix acheivement screen issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 | Version | Description |
 |---------|-------------|
+| | Fix crashing when using Acheivement Screens | |
 | 2.0.7 | |
 | | Remove fullscreen api usage | |
 | | Remove disable of background elements on modals as now handled automatically in cage. | |
-| 2.0.6 | |
+| 2.0.6 | | 
 | | Reports title from character-select assets rather than the asset key | |
 | 2.0.5 | |
 | | Calls to 'visible' on accessible dom elements now reliable after creation. (CGPROD-1585) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 | 2.0.7 | |
 | | Remove fullscreen api usage | |
 | | Remove disable of background elements on modals as now handled automatically in cage. | |
-| 2.0.6 | | 
+| 2.0.6 | |
 | | Reports title from character-select assets rather than the asset key | |
 | 2.0.5 | |
 | | Calls to 'visible' on accessible dom elements now reliable after creation. (CGPROD-1585) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -232,12 +232,12 @@ export const config = {
         channel: buttonsChannel,
         action: ({ game }) => {
             const screen = game.state.states[game.state.current];
+            screen.scene.getLayouts()[0].buttons.achievements.setIndicator();
             if (screen.navigation.achievements) {
                 screen.navigation.achievements();
             } else {
                 gmi.achievements.show();
             }
-            screen.scene.getLayouts()[0].buttons.achievements.setIndicator();
         },
     },
     restart: {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -235,7 +235,13 @@ describe("Layout - Gel Defaults", () => {
             expect(mockGmi.achievements.show).toHaveBeenCalled();
         });
 
-        test("clears the indicator", () => {
+        test("clears the indicator when there is a achievements screen", () => {
+            gel.config.achievements.action({ game: mockGame });
+            expect(clearIndicatorSpy).toHaveBeenCalled();
+        });
+
+        test("clears the indicator when using the GMI Acheivements view", () => {
+            delete mockCurrentScreen.navigation.achievements;
             gel.config.achievements.action({ game: mockGame });
             expect(clearIndicatorSpy).toHaveBeenCalled();
         });


### PR DESCRIPTION
While converting the Genie Trajectory  game i noticed that when trying to go to an acheivement screen the game would crash due to type errors. This seemed to be because it was trying to read from the home page's layout after the home page had been torn down.

This PR reorders the calls to ensure that layouts will exist when we search the layout.

