### PR TITLE
CGPROD-1824 Achievement and home stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
-| | Stats for opening achievements and home buttons | |
+| | Stats for achievement screens and home buttons | |
 | | Fix crashing when using Acheivement Screens | |
 | 2.0.7 | |
 | | Remove fullscreen api usage | |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 | Version | Description |
 |---------|-------------|
+| | Stats for opening achievements and home buttons | |
 | | Fix crashing when using Acheivement Screens | |
 | 2.0.7 | |
 | | Remove fullscreen api usage | |

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -152,15 +152,6 @@ export const config = {
         id: "__previous",
         channel: buttonsChannel,
     },
-    previous: {
-        group: "middleLeftSafe",
-        title: "Previous",
-        key: "previous",
-        ariaLabel: "Previous Item",
-        order: 7,
-        id: "__previous",
-        channel: buttonsChannel,
-    },
     howToPlayPrevious: {
         group: "middleLeftSafe",
         title: "Previous",

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -61,7 +61,12 @@ export const config = {
         order: 2,
         id: "__back",
         channel: buttonsChannel,
-        action: () => {
+        action: ({ game }) => {
+            const screen = game.state.states[game.state.current];
+
+            if (screen.key === "achievements") {
+                gmi.sendStatsEvent("achievements", "close");
+            }
             gmi.sendStatsEvent("back", "click");
         },
     },
@@ -137,6 +142,15 @@ export const config = {
             gmi.sendStatsEvent("pause", "click");
             pause.create(true, { game });
         },
+    },
+    previous: {
+        group: "middleLeftSafe",
+        title: "Previous",
+        key: "previous",
+        ariaLabel: "Previous Item",
+        order: 7,
+        id: "__previous",
+        channel: buttonsChannel,
     },
     previous: {
         group: "middleLeftSafe",
@@ -236,9 +250,8 @@ export const config = {
 
             screen.scene.getLayouts()[0].buttons.achievements.setIndicator();
 
-            gmi.sendStatsEvent("achievements", "open");
-
             if (screen.navigation.achievements) {
+                gmi.sendStatsEvent("achievements", "open");
                 screen.navigation.achievements();
             } else {
                 gmi.achievements.show();

--- a/src/core/layout/gel-defaults.js
+++ b/src/core/layout/gel-defaults.js
@@ -40,6 +40,7 @@ export const config = {
         channel: buttonsChannel,
         action: ({ game }) => {
             const screen = game.state.states[game.state.current];
+            gmi.sendStatsEvent("home", "click");
             screen.navigation.home();
         },
     },
@@ -232,7 +233,11 @@ export const config = {
         channel: buttonsChannel,
         action: ({ game }) => {
             const screen = game.state.states[game.state.current];
+
             screen.scene.getLayouts()[0].buttons.achievements.setIndicator();
+
+            gmi.sendStatsEvent("achievements", "open");
+
             if (screen.navigation.achievements) {
                 screen.navigation.achievements();
             } else {

--- a/test/core/layout/gel-defaults.test.js
+++ b/test/core/layout/gel-defaults.test.js
@@ -78,12 +78,21 @@ describe("Layout - Gel Defaults", () => {
     });
 
     describe("Back Button Callback", () => {
-        beforeEach(() => {
-            gel.config.back.action();
+        test("fires a click stat", () => {
+            gel.config.back.action({ game: mockGame });
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("back", "click");
         });
 
-        test("fires a click stat", () => {
-            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("back", "click");
+        test("when backing out of an achievements page a stat is fired", () => {
+            const mockGame = {
+                state: {
+                    current: "achievements",
+                    states: { achievements: { key: "achievements" } },
+                },
+            };
+
+            gel.config.back.action({ game: mockGame });
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("achievements", "close");
         });
     });
 
@@ -233,6 +242,12 @@ describe("Layout - Gel Defaults", () => {
             delete mockCurrentScreen.navigation.achievements;
             gel.config.achievements.action({ game: mockGame });
             expect(mockGmi.achievements.show).toHaveBeenCalled();
+        });
+
+        test("calls 'achievements open' stats when local screen exists", () => {
+            gel.config.achievements.action({ game: mockGame });
+            expect(mockCurrentScreen.navigation.achievements).toHaveBeenCalled();
+            expect(mockGmi.sendStatsEvent).toHaveBeenCalledWith("achievements", "open");
         });
 
         test("clears the indicator when there is a achievements screen", () => {


### PR DESCRIPTION
![ptb_lrg-804x398](https://user-images.githubusercontent.com/18242642/66490214-babf1100-eaa8-11e9-8819-57c6eb90b52e.jpg)

Stats for opening and closing achievement screens. removes the need for games to handle this.
Stats for pressing the home button. (This could be expanded to tell us where in the game the button was pressed).