### PR TITLE
CGPROD-2491 Add iPhone 5 padding

### DIFF
--- a/src/components/loadscreen.js
+++ b/src/components/loadscreen.js
@@ -75,8 +75,8 @@ export class Loadscreen extends Screen {
     createBrandLogo() {
         const metrics = Scaler.getMetrics();
 
-        const x = metrics.horizontals.right - metrics.borderPad / metrics.scale;
-        const y = metrics.verticals.bottom - metrics.borderPad / metrics.scale;
+        const x = metrics.horizontals.right - metrics.horizontalBorderPad / metrics.scale;
+        const y = metrics.verticals.bottom - metrics.verticalBorderPad / metrics.scale;
         this.brandLogo = this.scene.addToBackground(this.game.add.image(0, 0, "brandLogo"));
         this.brandLogo.right = x;
         this.brandLogo.bottom = y;

--- a/src/core/layout/calculate-metrics.js
+++ b/src/core/layout/calculate-metrics.js
@@ -22,7 +22,9 @@ export const calculateMetrics = fp.curry((stageHeight, { width, height }) => {
     const aspectRatio = fp.clamp(GEL_MIN_ASPECT_RATIO, GEL_MAX_ASPECT_RATIO, width / height);
     const stageWidth = aspectRatio * stageHeight;
     const isMobile = width < MOBILE_BREAK_WIDTH;
+    const isIphone5 = width === 568 && height === 320;
     const safeWidth = stageHeight * GEL_MIN_ASPECT_RATIO;
+    const borderPad = fp.floor(fp.max([stageWidth, stageHeight]) * BORDER_PAD_RATIO);
 
     const metrics = {
         width,
@@ -30,7 +32,8 @@ export const calculateMetrics = fp.curry((stageHeight, { width, height }) => {
         scale,
         stageWidth,
         stageHeight,
-        borderPad: fp.floor(fp.max([stageWidth, stageHeight]) * BORDER_PAD_RATIO),
+        verticalBorderPad: isIphone5 ? 32 : borderPad,
+        horizontalBorderPad: borderPad,
         isMobile,
         buttonPad: isMobile ? 22 : 24,
         buttonMin: isMobile ? 42 : 64,

--- a/src/core/layout/group.js
+++ b/src/core/layout/group.js
@@ -14,7 +14,7 @@ const horizontal = {
             if (!child.hitArea) return;
             hitAreaOffset = fp.max([hitAreaOffset, -(child.x + child.hitArea.left) / metrics.scale]);
         }, group.children);
-        group.left = metrics[horizontalsType].left + metrics.borderPad + hitAreaOffset;
+        group.left = metrics[horizontalsType].left + metrics.horizontalBorderPad + hitAreaOffset;
     },
     center: (metrics, group, horizontalsType) => {
         group.centerX = metrics[horizontalsType].center;
@@ -25,7 +25,7 @@ const horizontal = {
             if (!child.hitArea) return;
             hitAreaOffset = fp.max([hitAreaOffset, (child.x + child.hitArea.right) / metrics.scale - group.width]);
         }, group.children);
-        group.right = metrics[horizontalsType].right - metrics.borderPad - hitAreaOffset;
+        group.right = metrics[horizontalsType].right - metrics.horizontalBorderPad - hitAreaOffset;
     },
 };
 
@@ -36,7 +36,7 @@ const vertical = {
             if (!child.hitArea) return;
             hitAreaOffset = fp.max([hitAreaOffset, -(child.y + child.hitArea.top) / metrics.scale]);
         }, group.children);
-        group.top = metrics.verticals.top + metrics.borderPad + hitAreaOffset;
+        group.top = metrics.verticals.top + metrics.verticalBorderPad + hitAreaOffset;
     },
     middle: (metrics, group) => {
         group.centerY = metrics.verticals.middle;
@@ -47,7 +47,7 @@ const vertical = {
             if (!child.hitArea) return;
             hitAreaOffset = fp.max([hitAreaOffset, (child.y + child.hitArea.bottom) / metrics.scale - group.height]);
         }, group.children);
-        group.bottom = metrics.verticals.bottom - metrics.borderPad - hitAreaOffset;
+        group.bottom = metrics.verticals.bottom - metrics.verticalBorderPad - hitAreaOffset;
     },
 };
 

--- a/test/core/layout/calculate-metrics.test.js
+++ b/test/core/layout/calculate-metrics.test.js
@@ -28,15 +28,30 @@ describe("Layout - Calculate Metrics", () => {
     });
 
     describe("borderPad metric", () => {
-        test("sets a border padding of 2% of the longest edge", () => {
-            expect(getMetrics({ width: 600, height: 600 }).borderPad).toBe(16);
-            expect(getMetrics({ width: 800, height: 600 }).borderPad).toBe(16);
-            expect(getMetrics({ width: 1000, height: 600 }).borderPad).toBe(20);
-            expect(getMetrics({ width: 1500, height: 600 }).borderPad).toBe(28);
+        test("sets a vertical border padding of 2% of the longest edge when not an iPhone 5 (568x320)", () => {
+            expect(getMetrics({ width: 600, height: 600 }).verticalBorderPad).toBe(16);
+            expect(getMetrics({ width: 800, height: 600 }).verticalBorderPad).toBe(16);
+            expect(getMetrics({ width: 1000, height: 600 }).verticalBorderPad).toBe(20);
+            expect(getMetrics({ width: 1500, height: 600 }).verticalBorderPad).toBe(28);
 
-            expect(getMetrics({ width: 200, height: 600 }).borderPad).toBe(16);
-            expect(getMetrics({ width: 200, height: 800 }).borderPad).toBe(16);
-            expect(getMetrics({ width: 200, height: 1000 }).borderPad).toBe(16);
+            expect(getMetrics({ width: 200, height: 600 }).verticalBorderPad).toBe(16);
+            expect(getMetrics({ width: 200, height: 800 }).verticalBorderPad).toBe(16);
+            expect(getMetrics({ width: 200, height: 1000 }).verticalBorderPad).toBe(16);
+        });
+
+        test("sets a vertical border padding of 32 when it is a iPhone 5 (568x320)", () => {
+            expect(getMetrics({ width: 568, height: 320 }).verticalBorderPad).toBe(32);
+        });
+
+        test("sets a horizontal border padding of 2% of the longest edge", () => {
+            expect(getMetrics({ width: 600, height: 600 }).horizontalBorderPad).toBe(16);
+            expect(getMetrics({ width: 800, height: 600 }).horizontalBorderPad).toBe(16);
+            expect(getMetrics({ width: 1000, height: 600 }).horizontalBorderPad).toBe(20);
+            expect(getMetrics({ width: 1500, height: 600 }).horizontalBorderPad).toBe(28);
+
+            expect(getMetrics({ width: 200, height: 600 }).horizontalBorderPad).toBe(16);
+            expect(getMetrics({ width: 200, height: 800 }).horizontalBorderPad).toBe(16);
+            expect(getMetrics({ width: 200, height: 1000 }).horizontalBorderPad).toBe(16);
         });
     });
 

--- a/test/core/layout/group.test.js
+++ b/test/core/layout/group.test.js
@@ -25,7 +25,8 @@ describe("Group", () => {
         };
         config = {};
         metrics = {
-            borderPad: 100,
+            horizontalBorderPad: 100,
+            verticalBorderPad: 100,
             buttonPad: 50,
             horizontals: { left: -1000, center: 0, right: 1000 },
             safeHorizontals: { left: -300, center: 0, right: 300 },
@@ -256,7 +257,7 @@ describe("Group", () => {
             const expectedGroupXPosition = 0;
             const expectedGroupYPosition = -333;
             const desktopMetrics = { horizontals: {}, verticals: {} };
-            const moreDesktopMetrics = { borderPad: 0, horizontals: { center: 0 }, verticals: { top: -333 } };
+            const moreDesktopMetrics = { verticalBorderPad: 0, horizontals: { center: 0 }, verticals: { top: -333 } };
 
             group = new Group(game, parentGroup, "top", "center", desktopMetrics, false);
             group.addButton(config);


### PR DESCRIPTION
Add vertcal padding when screen matches iPhone 5 resolution to sidestep
issue of buttons interfering with browser behaviour.

https://jira.dev.bbc.co.uk/browse/CGPROD-2491

.