### PR TITLE
CGPROD-2507_Achievements-Blip-Amendments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 | Version | Description |
 |---------|-------------|
+| 2.0.14 | |
+| | Amends the achievements signal to fire when achievements is closed rather than when toast notification is fired. | |
 | 2.0.13 | |
 | | Adds a signal to update the achievements indicator when a notification has been fired. | |
 | 2.0.12 | |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "genie",
-    "version": "2.0.13",
+    "version": "2.0.14",
     "description": "Genie - A Modular Game Engine",
     "license": "Apache-2.0",
     "private": true,

--- a/src/components/loadscreen.js
+++ b/src/components/loadscreen.js
@@ -52,10 +52,14 @@ export class Loadscreen extends Screen {
             GameSound.setButtonClickSound(this.game, "loadscreen.buttonClick");
 
             if (this.context.config.theme.game && this.context.config.theme.game.achievements === true) {
-                const achievementsCallBack = () => {
-                    signal.bus.publish({ channel: achievementsChannel, name: "achievement-notification-close" });
+                const achievementsCloseCallBack = () => {
+                    signal.bus.publish({ channel: achievementsChannel, name: "achievements-close" });
                 };
-                gmi.achievements.init(this.game.cache.getJSON("achievementsData"), achievementsCallBack);
+                gmi.achievements.init(
+                    this.game.cache.getJSON("achievementsData"),
+                    undefined,
+                    achievementsCloseCallBack,
+                );
             }
             gmi.sendStatsEvent("gameloaded", "true");
             gmi.gameLoaded();

--- a/src/components/results.js
+++ b/src/components/results.js
@@ -61,7 +61,7 @@ export class Results extends Screen {
         });
 
         signal.bus.subscribe({
-            name: "achievement-notification-close",
+            name: "achievements-close",
             channel: achievementsChannel,
             callback: () => {
                 this.scene.getLayouts()[0].buttons.achievements.setIndicator();

--- a/test/components/loadscreen.test.js
+++ b/test/components/loadscreen.test.js
@@ -224,17 +224,17 @@ describe("Load Screen", () => {
             expect(mockGmi.achievements.init).not.toHaveBeenCalled();
         });
 
-        test("publishes a signal when a notification has fired", () => {
+        test("publishes a signal when the achievements is closed", () => {
             jest.spyOn(signal.bus, "publish");
             mockContext.config.theme.game.achievements = true;
             loadScreen.context = mockContext;
             loadScreen.preload();
             assetLoaderCallbackSpy.mock.calls[0][0]();
-            mockGmi.achievements.init.mock.calls[0][1]();
+            mockGmi.achievements.init.mock.calls[0][2]();
 
             expect(signal.bus.publish).toHaveBeenCalledWith({
                 channel: achievementsChannel,
-                name: "achievement-notification-close",
+                name: "achievements-close",
             });
         });
     });

--- a/test/components/results.test.js
+++ b/test/components/results.test.js
@@ -175,7 +175,7 @@ describe("Results Screen", () => {
 
         describe("achievement notification closed", () => {
             test("adds a signal subscription", () => {
-                expect(signal.bus.subscribe.mock.calls[2][0].name).toBe("achievement-notification-close");
+                expect(signal.bus.subscribe.mock.calls[2][0].name).toBe("achievements-close");
                 expect(signal.bus.subscribe.mock.calls[2][0].channel).toBe(achievementsChannel);
             });
 


### PR DESCRIPTION
Switches callback to fire when achievements is closed rather than when an achievement notification is fired. This means the blip is always updated correctly when the achievements is closed.